### PR TITLE
Fix package inclusion in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+# Include all Python files in the moduflow package and its submodules
+recursive-include moduflow *.py
+recursive-include moduflow/*/*.py
+
+# Exclude tests
+exclude tests/*

--- a/moduflow/__init__.py
+++ b/moduflow/__init__.py
@@ -6,5 +6,5 @@ supporting Test-Driven Development, and organizing projects into logical
 components that can be developed and tested independently.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.3"
 __author__ = "Brian Onang'o"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moduflow"
-version = "0.1.0"
+version = "0.1.3"
 description = "Section-based development with Test-Driven Development support"
 readme = "README.md"
 authors = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = moduflow
-version = 0.1.0
+version = 0.1.3
 description = Section-based development with Test-Driven Development support
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Update MANIFEST.in to include all Python files in moduflow and its submodules. Exclude the tests directory from the distribution to avoid shipping unnecessary test files.